### PR TITLE
Use the Task-based asynchonous model

### DIFF
--- a/VirtualMeetingMonitor/App.config
+++ b/VirtualMeetingMonitor/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
 </configuration>

--- a/VirtualMeetingMonitor/Form.cs
+++ b/VirtualMeetingMonitor/Form.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace VirtualMeetingMonitor
@@ -13,7 +14,7 @@ namespace VirtualMeetingMonitor
         private readonly VirtualMeeting meeting = new VirtualMeeting();
         readonly Timer timer = new Timer();
         private const string LogFileName = "meetings.txt";
-
+        private Task networkListener;
 
         public Form()
         {
@@ -27,7 +28,7 @@ namespace VirtualMeetingMonitor
             timer.Tick += OnTimerEvent;
 
             network.OutsideUDPTafficeReceived += Network_OutsideUDPTafficeReceived;
-            network.StartListening();
+            networkListener = network.StartListening();
 
             meeting.OnMeetingStarted += Meeting_OnMeetingStarted;
             meeting.OnMeetingEnded += Meeting_OnMeetingEnded;
@@ -141,9 +142,11 @@ namespace VirtualMeetingMonitor
             meeting.CheckMeetingStatus();
         }
 
-        private void Form1_FormClosing(object sender, FormClosingEventArgs e)
+        private async void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
             network.Stop();
+            //By awaiting the network listening task, we ensure that the task can be disposed, releasing its resources.
+            await networkListener;
         }
 
         private void openLogToolStripMenuItem_Click(object sender, EventArgs e)

--- a/VirtualMeetingMonitor/Network.cs
+++ b/VirtualMeetingMonitor/Network.cs
@@ -21,7 +21,17 @@ namespace VirtualMeetingMonitor
         {
 
             SetupLocalIp();
+            ConfigureSocket();
 
+            //Start receiving the packets asynchronously
+            mainSocket.BeginReceive(byteData, 0, byteData.Length, SocketFlags.None, OnReceive, null);
+        }
+
+        /// <summary>
+        /// Configures the listening socket
+        /// </summary>
+        private void ConfigureSocket()
+        {
             //For sniffing the socket to capture the packets has to be a raw socket, with the
             //address family being of type internetwork, and protocol being IP
             mainSocket = new Socket(AddressFamily.InterNetwork, SocketType.Raw, ProtocolType.IP);
@@ -33,15 +43,12 @@ namespace VirtualMeetingMonitor
             //Set the socket  options
             mainSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.HeaderIncluded, true);
 
-            byte[] True = new byte[] { 1, 0, 0, 0 };
-            byte[] Out = new byte[] { 1, 0, 0, 0 }; //Capture outgoing packets
+            byte[] True = new byte[] {1, 0, 0, 0};
+            byte[] Out = new byte[] {1, 0, 0, 0}; //Capture outgoing packets
 
             //Socket.IOControl is analogous to the WSAIoctl method of Winsock 2
             // The current user must belong to the Administrators group on the local computer
             mainSocket.IOControl(IOControlCode.ReceiveAll, True, Out);
-
-            //Start receiving the packets asynchronously
-            mainSocket.BeginReceive(byteData, 0, byteData.Length, SocketFlags.None, OnReceive, null);
         }
 
         /// <summary>

--- a/VirtualMeetingMonitor/Network.cs
+++ b/VirtualMeetingMonitor/Network.cs
@@ -20,18 +20,7 @@ namespace VirtualMeetingMonitor
         public void StartListening()
         {
 
-            IPHostEntry HosyEntry = Dns.GetHostEntry((Dns.GetHostName()));
-            if (HosyEntry.AddressList.Any())
-            {
-                foreach (IPAddress ip in HosyEntry.AddressList)
-                {
-                    if (ip.AddressFamily == AddressFamily.InterNetwork)
-                    {
-                        localIp = ip;
-                        break;
-                    }
-                }
-            }
+            SetupLocalIp();
 
             //For sniffing the socket to capture the packets has to be a raw socket, with the
             //address family being of type internetwork, and protocol being IP
@@ -53,6 +42,26 @@ namespace VirtualMeetingMonitor
 
             //Start receiving the packets asynchronously
             mainSocket.BeginReceive(byteData, 0, byteData.Length, SocketFlags.None, OnReceive, null);
+        }
+
+        /// <summary>
+        /// Set up a local IP address from the list of available addresses.
+        /// The first available IPv4 is chosen as the local IP address.
+        /// </summary>
+        private void SetupLocalIp()
+        {
+            IPHostEntry HosyEntry = Dns.GetHostEntry((Dns.GetHostName()));
+            if (HosyEntry.AddressList.Any())
+            {
+                foreach (IPAddress ip in HosyEntry.AddressList)
+                {
+                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                    {
+                        localIp = ip;
+                        break;
+                    }
+                }
+            }
         }
 
         public void Stop()

--- a/VirtualMeetingMonitor/VirtualMeetingMonitor.csproj
+++ b/VirtualMeetingMonitor/VirtualMeetingMonitor.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VirtualMeetingMonitor</RootNamespace>
     <AssemblyName>VirtualMeetingMonitor</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #3 

In this PR I've switched the asynchronous pattern from the old BeginX/EndX to the more modern Task-based API. The PR consists of a number of small commits so that it's easier to follow along. The PR consists of the following logical steps:
* Upgrade the .NET framework to allow using the Task-based API for sockets.
* Refactor the StartListening method. The method was doing multiple things, these have been separated out into their own, smaller methods. The overall flow is still the same, but it's easier to get an overview of that the code is doing, due to the smaller method sizes.
* Refactor from using the BeginReceive/EndReceive pattern to using a Task for the purpose. This change is contained in its own commit to make it clear what parts I changed to implement this.

The logic behind how packets are processed is simpler as the async parts are now in a central place, instead of being spread across multiple methods. This allows us to use a simpler mental model of what is happening: Loop to receive packets, handle them as they arrive, shut down when the socket is closed.

I've tested that the app still runs, but async code is tricky; there could easily be something I've overlooked. Do test thouroughly before merging anyhing from the latest commit in this PR. Please let me know if you can spot any behaviour that changes due to this PR. :-)